### PR TITLE
Medtronic 640G Pump - Site Change

### DIFF
--- a/src/davidRichardson/DBResultMedtronic.java
+++ b/src/davidRichardson/DBResultMedtronic.java
@@ -316,7 +316,7 @@ public class DBResultMedtronic extends DBResult
 				
 				
 			    	// Site Change
-			    	else if ((m_RecordSet[m_PrimeIndex].length() > 0) && (m_RecordSet[m_PrimeIndex] == "Fill Cannula")
+			    	else if ((m_RecordSet[m_PrimeIndex].length() > 0) && (m_RecordSet[m_PrimeIndex] == "Fill Cannula"))
 			    	{
 			    		this.m_CP_EventType = "Site Change";
 			    	}

--- a/src/davidRichardson/DBResultMedtronic.java
+++ b/src/davidRichardson/DBResultMedtronic.java
@@ -76,7 +76,7 @@ public class DBResultMedtronic extends DBResult
 	static private int m_CarbAmountIndex = 0;
 	static private int m_StandardBolusIndex = 0;
 	static private int m_BolusDurationIndex = 0;
-	static private int m_RewindInsulin = 0;
+	static private int m_PrimeIndex = 0;
 
 	@Override
 	public boolean isValid()
@@ -312,11 +312,11 @@ public class DBResultMedtronic extends DBResult
 			    	{
 			    		this.m_Result = m_RecordSet[m_CarbAmountIndex];
 			    		this.m_ResultType = "Carbs";
-			    	}
+ 			    	}
 				
 				
 			    	// Site Change
-			    	else if (m_RecordSet[m_rewindInsulinIndex].length() > 0)
+			    	else if ((m_RecordSet[m_PrimeIndex].length() > 0) && (m_RecordSet[m_PrimeIndex] == "Fill Cannula")
 			    	{
 			    		this.m_CP_EventType = "Site Change";
 			    	}
@@ -352,7 +352,7 @@ public class DBResultMedtronic extends DBResult
 			m_StandardBolusIndex = fieldLocation("Bolus Volume Delivered (U)");
 			m_BolusDurationIndex = fieldLocation("Bolus Duration (hh:mm:ss)");
 //			m_Time = fieldLocation("Timestamp");
-			m_rewindInsulinIndex = fieldLocation("Rewind");
+			m_PrimeIndex = fieldLocation("Prime Type");
 						
 			m_indexesInitialized = true;
 		}

--- a/src/davidRichardson/DBResultMedtronic.java
+++ b/src/davidRichardson/DBResultMedtronic.java
@@ -76,6 +76,7 @@ public class DBResultMedtronic extends DBResult
 	static private int m_CarbAmountIndex = 0;
 	static private int m_StandardBolusIndex = 0;
 	static private int m_BolusDurationIndex = 0;
+	static private int m_RewindInsulin = 0;
 
 	@Override
 	public boolean isValid()
@@ -312,6 +313,13 @@ public class DBResultMedtronic extends DBResult
 			    		this.m_Result = m_RecordSet[m_CarbAmountIndex];
 			    		this.m_ResultType = "Carbs";
 			    	}
+				
+				
+			    	// Site Change
+			    	else if (m_RecordSet[m_rewindInsulinIndex].length() > 0)
+			    	{
+			    		this.m_CP_EventType = "Site Change";
+			    	}
 			    	
 			        // Not interested, so make invalid and it's discarded
 			    	else
@@ -344,6 +352,7 @@ public class DBResultMedtronic extends DBResult
 			m_StandardBolusIndex = fieldLocation("Bolus Volume Delivered (U)");
 			m_BolusDurationIndex = fieldLocation("Bolus Duration (hh:mm:ss)");
 //			m_Time = fieldLocation("Timestamp");
+			m_rewindInsulinIndex = fieldLocation("Rewind");
 						
 			m_indexesInitialized = true;
 		}


### PR DESCRIPTION
Determine if a pump site change has occurred based on a "Prime Type" of "Fill Cannula".
This appears to be the easiest way to check for a site change, as a tubing fill or a rewind event can't be used (they also occur at an insulin change).

Untested, as I haven't built java in *years* (sorry)