### PR TITLE
Fix autotune profile editor cast error

### DIFF
--- a/src/davidRichardson/DataLoadDiasend.java
+++ b/src/davidRichardson/DataLoadDiasend.java
@@ -937,11 +937,9 @@ public class DataLoadDiasend extends DataLoadBase
 			HSSFSheet insulinSheet = wb.getSheet(m_InsulinTabName);
 			HSSFSheet cgmSheet = wb.getSheet(m_CGMTabName);
 
-			//			if ( (glucoseSheet != null && glucoseSheet.getPhysicalNumberOfRows() > 0) // Glucose tab is there with rows
-			//					&&   (insulinSheet != null && insulinSheet.getPhysicalNumberOfRows() > 0))// Insulin tab is also there with rows
 			if ( (glucoseSheet != null && glucoseSheet.getLastRowNum() > 0) // Glucose tab is there with rows
-					&&   ((insulinSheet != null && insulinSheet.getLastRowNum() > 0)// Insulin tab is also there with rows
-							|| (cgmSheet != null && cgmSheet.getLastRowNum() > 0))) // Or CGM tab is there with rows
+					|| (insulinSheet != null && insulinSheet.getLastRowNum() > 0)// Or Insulin tab is there with rows
+					|| (cgmSheet != null && cgmSheet.getLastRowNum() > 0)) // Or CGM tab is there with rows
 			{
 				result = true;
 			}

--- a/src/davidRichardson/DataLoadDiasend.java
+++ b/src/davidRichardson/DataLoadDiasend.java
@@ -935,17 +935,17 @@ public class DataLoadDiasend extends DataLoadBase
 
 			HSSFSheet glucoseSheet = wb.getSheet(m_GlucoseTabName);
 			HSSFSheet insulinSheet = wb.getSheet(m_InsulinTabName);
+			HSSFSheet cgmSheet = wb.getSheet(m_CGMTabName);
 
 			//			if ( (glucoseSheet != null && glucoseSheet.getPhysicalNumberOfRows() > 0) // Glucose tab is there with rows
 			//					&&   (insulinSheet != null && insulinSheet.getPhysicalNumberOfRows() > 0))// Insulin tab is also there with rows
 			if ( (glucoseSheet != null && glucoseSheet.getLastRowNum() > 0) // Glucose tab is there with rows
-					&&   (insulinSheet != null && insulinSheet.getLastRowNum() > 0))// Insulin tab is also there with rows
-
+					&&   ((insulinSheet != null && insulinSheet.getLastRowNum() > 0)// Insulin tab is also there with rows
+							|| (cgmSheet != null && cgmSheet.getLastRowNum() > 0))) // Or CGM tab is there with rows
 			{
 				result = true;
 			}
 			wb.close();
-
 		} 
 		catch(Exception ioe) 
 		{

--- a/src/davidRichardson/WinAutotuneProfile.java
+++ b/src/davidRichardson/WinAutotuneProfile.java
@@ -389,7 +389,9 @@ public class WinAutotuneProfile extends JFrame
 		{
 			String start   = (String)((JSONObject)elem).get("start");
 			//   		long   minutes = (long)((JSONObject)elem).get("minutes");
-			double rate    = (double)((JSONObject)elem).get("rate");
+			//Store rate as a string, then parse to double in case rate is an Integer
+			String rateStr = ((JSONObject)elem).get("rate").toString();
+			double rate = Double.parseDouble(rateStr);
 
 			int hour = Integer.parseInt(start.substring(0, 2));
 			if (hour < 24)


### PR DESCRIPTION
I discovered that the autotune profile editor wasn't displaying for me due to a cast exception being thrown, one of the basal rates specified in my profile.json was a whole number so was being treated as a Long. Storing the rate as a String then casting to Double resolves this.