### PR TITLE
add support for diasend xls format change

### DIFF
--- a/.idea/libraries/org_jfree_jfreechart_1_0_19.xml
+++ b/.idea/libraries/org_jfree_jfreechart_1_0_19.xml
@@ -4,7 +4,6 @@
     <CLASSES>
       <root url="jar://$MAVEN_REPOSITORY$/org/jfree/jfreechart/1.0.19/jfreechart-1.0.19.jar!/" />
       <root url="jar://$MAVEN_REPOSITORY$/org/jfree/jcommon/1.0.23/jcommon-1.0.23.jar!/" />
-      <root url="jar://$MAVEN_REPOSITORY$/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar!/" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/davidRichardson/DBResultDiasend.java
+++ b/src/davidRichardson/DBResultDiasend.java
@@ -50,6 +50,8 @@ public class DBResultDiasend extends DBResult
 				"Duration (min)",
 				"Carbs(g)",
 				"Notes",
+				"Total daily dose",
+				"Total daily basal",
 		};
 	static private int m_InsulinTimeIndex = 0;
 	static private int m_InsulinBasalAmountIndex = 0;
@@ -60,6 +62,8 @@ public class DBResultDiasend extends DBResult
 	static private int m_InsulinDurationIndex = 0;
 	static private int m_InsulinCarbsIndex = 0;
 	//	static private int m_InsulinNotesIndex = 0;
+	//	static private int m_InsulinTotalDailyDoseIndex = 0;
+	//	static private int m_InsulinTotalDailyBasalIndex = 0;
 
 
 	public boolean isValid()
@@ -262,6 +266,8 @@ public class DBResultDiasend extends DBResult
 		Double bolDurDbl    = getDoubleCellValue(row, m_InsulinDurationIndex);
 		Double carbAmtDbl   = getDoubleCellValue(row, m_InsulinCarbsIndex);
 		//		String notesStr     = getStringCellValue(row, m_InsulinNotesIndex);
+		//		Double totalDailyDoseAmtDbl     = getStringCellValue(row, m_InsulinTotalDailyDoseIndex);
+		//		Double m_totalDailyBasalAmtDbl     = getStringCellValue(row, m_InsulinTotalDailyBasalIndex);
 
 		// Not sure how data looks for square waves as yet ...
 
@@ -274,6 +280,7 @@ public class DBResultDiasend extends DBResult
 			if (d.getTime() == 0)
 			{
 				m_Valid=false;
+				return;
 			}
 			else
 			{
@@ -282,6 +289,11 @@ public class DBResultDiasend extends DBResult
 				m_Valid = true;
 				setDateFields();
 			}
+		}
+		else
+		{
+			m_Valid=false;//time must be set on each row
+			return;
 		}
 
 		// Bolus?
@@ -416,6 +428,8 @@ public class DBResultDiasend extends DBResult
 						case 6 : m_InsulinDurationIndex        = c; break;
 						case 7 : m_InsulinCarbsIndex           = c; break;
 						//						case 8 : m_InsulinNotesIndex           = c; break;
+							// 						case 9 : m_InsulinTotalDailyDoseIndex           = c; break;
+							//						case 10 : m_InsulinTotalDailyBasalIndex           = c; break;
 						default :                                  break;
 						}
 					}

--- a/src/davidRichardson/DBResultDiasend.java
+++ b/src/davidRichardson/DBResultDiasend.java
@@ -224,6 +224,20 @@ public class DBResultDiasend extends DBResult
 		return result;
 	}
 
+	boolean isCellEmpty(HSSFRow row, int index)
+	{
+
+		HSSFCell cell = row.getCell(index);
+		if (cell != null && (cell.getCellType() != HSSFCell.CELL_TYPE_BLANK))
+		{
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+
 	private void loadRawGlucose(HSSFRow row)
 	{
 		String timeStr  = getStringCellValue(row, m_GlucoseTimeIndex);
@@ -342,7 +356,7 @@ public class DBResultDiasend extends DBResult
 
 		// Now store the Basals and allow the controlling loader to decide whether it's of interest or not
 		//		else if (basAmtDbl != null)
-		else if (basAmtDbl != null)//KS Basals can be 0!   && !basAmtDbl.equals(0.0))// David 28 Jan 2017.  Diagnosing issues with odd temp basals
+		else if (basAmtDbl != null && !isCellEmpty(row, m_InsulinBasalAmountIndex))//KS Basals can be 0!   && !basAmtDbl.equals(0.0))// David 28 Jan 2017.  Diagnosing issues with odd temp basals
 		{
 			this.m_ResultType = "Basal";
 			this.m_Result     = basAmtDbl.toString();


### PR DESCRIPTION
Diasend seems to have added a couple of new Inuslin fields to the xls which caused import to fail:

`Total daily dose | Total daily basal`

This PR just ignores these fields.

Also, Diasend export now adds invalid Insulin `Time` data as `0.000` in some rows.  These also need to be ignored to prevent import failure.


