### PR TITLE
Fix initializeCGMHeaders's column count check

### DIFF
--- a/src/davidRichardson/DBResultEntryDiasend.java
+++ b/src/davidRichardson/DBResultEntryDiasend.java
@@ -48,7 +48,7 @@ public class DBResultEntryDiasend extends DBResultEntry
 		if (m_CGMIndexesInitialized == false)
 		{
 			int maxColumns = row.getPhysicalNumberOfCells();
-			if (maxColumns == m_CGMFieldNames.length)
+			if (maxColumns >= m_CGMFieldNames.length)
 			{
 				int c = 0;
 


### PR DESCRIPTION
Spent a good evening trying to figure why it was getting CGM data from the time column!

My header looks like this:
![image](https://user-images.githubusercontent.com/355114/69290080-9a7d8880-0bf6-11ea-9542-8878020b5fe4.png)


I also had to modify the hardcoded values for `m_CGMRowDataHeaders` and `...Start`