### PR TITLE
Detect where the row CGM headers are at instead of hardcoding them

### DIFF
--- a/src/davidRichardson/DBResultEntryDiasend.java
+++ b/src/davidRichardson/DBResultEntryDiasend.java
@@ -43,32 +43,34 @@ public class DBResultEntryDiasend extends DBResultEntry
 		loadRawCGM(row);
 	}
 	
-	public static void initializeCGMHeaders(HSSFRow row)
+	// Checks whether row contains CGM headers. Returns true if it does, and fills variables with the index
+	public static boolean initializeCGMHeaders(HSSFRow row)
 	{
-		if (m_CGMIndexesInitialized == false)
+		m_CGMTimeIndex = -1;
+		m_CGMBGIndex = -1;
+		int maxColumns = row.getPhysicalNumberOfCells();
+		if(maxColumns >= m_CGMFieldNames.length)
 		{
-			int maxColumns = row.getPhysicalNumberOfCells();
-			if (maxColumns == m_CGMFieldNames.length)
+			int c;
+			for (c=0; c<m_CGMFieldNames.length; c++) // iterate on column headers
 			{
-				int c = 0;
-
-				for (c=0; c<m_CGMFieldNames.length; c++)
+				String cell = row.getCell(c).getStringCellValue();
+				if (m_CGMFieldNames[c].contains(cell)) // match cells against expected column header strings
 				{
-					String cell = row.getCell(c).getStringCellValue();
-					if (m_CGMFieldNames[c].contains(cell))
-						//					if (cell.equals(m_CGMFieldNames[c]))
+					switch (c)
 					{
-						switch (c)
-						{
-						case 0 : m_CGMTimeIndex           = c; break;
-						case 1 : m_CGMBGIndex             = c; break;
-						default :                                  break;
-						}
+					case 0 : m_CGMTimeIndex = c; break;
+					case 1 : m_CGMBGIndex = c; break;
 					}
 				}
-				m_CGMIndexesInitialized = true;
 			}
 		}
+		if((m_CGMTimeIndex != -1) && (m_CGMBGIndex != -1))
+		{
+			m_Logger.log(Level.FINE, "<DBResultEntryDiasend> " + "Identified columns: CGM Time=" + (m_CGMTimeIndex+1) + ", CGM BG=" + (m_CGMBGIndex+1));
+			return true;
+		}
+		return false;
 	}
 
 	private void loadRawCGM(HSSFRow row)

--- a/src/davidRichardson/DataLoadDiasend.java
+++ b/src/davidRichardson/DataLoadDiasend.java
@@ -43,6 +43,8 @@ public class DataLoadDiasend extends DataLoadBase
 	
 	final static int m_CGMRowDataHeaders = 2;
 	final static int m_CGMRowDataStart   = 3;
+	// final static int m_CGMRowDataHeaders = 5;
+	// final static int m_CGMRowDataStart   = 6;
 		
 	final static String m_SettingsBasalStartString      = "Basal profiles";
 	final static String m_SettingsIntervalString        = "Interval";
@@ -537,6 +539,7 @@ public class DataLoadDiasend extends DataLoadBase
 			int tmp = 0;
 
 			// This trick ensures that we get the data properly even if it doesn't start from first few rows
+			// @Dune-jr 2019-11-23: not sure whether that's needed anymore
 			for(int i = 0; i < 10 || i < rows; i++) 
 			{
 				row = sheet.getRow(i);
@@ -547,20 +550,19 @@ public class DataLoadDiasend extends DataLoadBase
 				}
 			}
 
+			boolean headersInitialized = false;
 			for(int r = 0; r < rows; r++) 
 			{
 				row = sheet.getRow(r);
-
-				if (r+1 == m_CGMRowDataHeaders)
-				{
-					DBResultEntryDiasend.initializeCGMHeaders(row);
-				}
-				else if (r+1 >= m_CGMRowDataStart)
+				if(row == null)
+					continue;
+				if (!headersInitialized)
+					headersInitialized = DBResultEntryDiasend.initializeCGMHeaders(row);
+				else
 				{
 					DBResultEntryDiasend res = new DBResultEntryDiasend(row);
-						rawEntryResultsFromDB.add(res);
-//						m_Logger.log(Level.FINEST, "<"+this.getClass().getName()+">" + "Result added for " + res.toString());
-						m_Logger.log(Level.FINEST, "<DataLoadDiasend>" + "Result added for " + res.toString());
+					rawEntryResultsFromDB.add(res);
+					m_Logger.log(Level.FINEST, "<"+this.getClass().getName()+">" + "Result added for " + res.toString());
 				}
 			}
 		} 

--- a/src/davidRichardson/DataLoadDiasend.java
+++ b/src/davidRichardson/DataLoadDiasend.java
@@ -40,11 +40,6 @@ public class DataLoadDiasend extends DataLoadBase
 
 	final static int m_InsulinRowDataHeaders = 1;
 	final static int m_InsulinRowDataStart   = 2;
-	
-	final static int m_CGMRowDataHeaders = 2;
-	final static int m_CGMRowDataStart   = 3;
-	// final static int m_CGMRowDataHeaders = 5;
-	// final static int m_CGMRowDataStart   = 6;
 		
 	final static String m_SettingsBasalStartString      = "Basal profiles";
 	final static String m_SettingsIntervalString        = "Interval";


### PR DESCRIPTION
This replaces https://github.com/gh-davidr/NightscoutLoader/pull/14 with a more complete fix, hopefully more resilient than just fixing some hardcoded values.

It goes further than https://github.com/gh-davidr/NightscoutLoader/pull/14/commits/85c401a452931a12db694a1db5266fe6abb2dad5 to fix the problem of the new (?) diasend format of the CSG tab:

![image](https://user-images.githubusercontent.com/355114/69471016-f41aba00-0d92-11ea-9752-d52e81bfbd5c.png)

It fixes it for me, and should be backwards compatible with the spreadsheet @kskandispersonal based his work on